### PR TITLE
add an implemetation of asin

### DIFF
--- a/src/math/asin.rs
+++ b/src/math/asin.rs
@@ -1,0 +1,114 @@
+/* origin: FreeBSD /usr/src/lib/msun/src/e_asin.c */
+/*
+ * ====================================================
+ * Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+ *
+ * Developed at SunSoft, a Sun Microsystems, Inc. business.
+ * Permission to use, copy, modify, and distribute this
+ * software is freely granted, provided that this notice
+ * is preserved.
+ * ====================================================
+ */
+/* asin(x)
+ * Method :
+ *      Since  asin(x) = x + x^3/6 + x^5*3/40 + x^7*15/336 + ...
+ *      we approximate asin(x) on [0,0.5] by
+ *              asin(x) = x + x*x^2*R(x^2)
+ *      where
+ *              R(x^2) is a rational approximation of (asin(x)-x)/x^3
+ *      and its remez error is bounded by
+ *              |(asin(x)-x)/x^3 - R(x^2)| < 2^(-58.75)
+ *
+ *      For x in [0.5,1]
+ *              asin(x) = pi/2-2*asin(sqrt((1-x)/2))
+ *      Let y = (1-x), z = y/2, s := sqrt(z), and pio2_hi+pio2_lo=pi/2;
+ *      then for x>0.98
+ *              asin(x) = pi/2 - 2*(s+s*z*R(z))
+ *                      = pio2_hi - (2*(s+s*z*R(z)) - pio2_lo)
+ *      For x<=0.98, let pio4_hi = pio2_hi/2, then
+ *              f = hi part of s;
+ *              c = sqrt(z) - f = (z-f*f)/(s+f)         ...f+c=sqrt(z)
+ *      and
+ *              asin(x) = pi/2 - 2*(s+s*z*R(z))
+ *                      = pio4_hi+(pio4-2s)-(2s*z*R(z)-pio2_lo)
+ *                      = pio4_hi+(pio4-2f)-(2s*z*R(z)-(pio2_lo+2c))
+ *
+ * Special cases:
+ *      if x is NaN, return x itself;
+ *      if |x|>1, return NaN with invalid signal.
+ *
+ */
+
+use super::{get_high_word, get_low_word, with_set_low_word, fabs, sqrt};
+
+const PIO2_HI : f64 = 1.57079632679489655800e+00; /* 0x3FF921FB, 0x54442D18 */
+const PIO2_LO : f64 = 6.12323399573676603587e-17; /* 0x3C91A626, 0x33145C07 */
+/* coefficients for R(x^2) */
+const P_S0 : f64 =  1.66666666666666657415e-01; /* 0x3FC55555, 0x55555555 */
+const P_S1 : f64 = -3.25565818622400915405e-01; /* 0xBFD4D612, 0x03EB6F7D */
+const P_S2 : f64 =  2.01212532134862925881e-01; /* 0x3FC9C155, 0x0E884455 */
+const P_S3 : f64 = -4.00555345006794114027e-02; /* 0xBFA48228, 0xB5688F3B */
+const P_S4 : f64 =  7.91534994289814532176e-04; /* 0x3F49EFE0, 0x7501B288 */
+const P_S5 : f64 =  3.47933107596021167570e-05; /* 0x3F023DE1, 0x0DFDF709 */
+const Q_S1 : f64 = -2.40339491173441421878e+00; /* 0xC0033A27, 0x1C8A2D4B */
+const Q_S2 : f64 =  2.02094576023350569471e+00; /* 0x40002AE5, 0x9C598AC8 */
+const Q_S3 : f64 = -6.88283971605453293030e-01; /* 0xBFE6066C, 0x1B8D0159 */
+const Q_S4 : f64 =  7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
+
+fn comp_r(z : f64) -> f64
+{
+    let p = z*(P_S0+z*(P_S1+z*(P_S2+z*(P_S3+z*(P_S4+z*P_S5)))));
+    let q = 1.0+z*(Q_S1+z*(Q_S2+z*(Q_S3+z*Q_S4)));
+    return p/q;
+}
+
+pub fn asin(mut x : f64) -> f64
+{
+    let z : f64;
+    let r : f64;
+    let s : f64;
+    let hx : u32;
+    let ix : u32;
+
+    hx = get_high_word(x);
+    ix = hx & 0x7fffffff;
+    /* |x| >= 1 or nan */
+    if ix >= 0x3ff00000 {
+        let lx : u32;
+        lx = get_low_word(x);
+        if (ix-0x3ff00000 | lx) == 0 {
+            /* asin(1) = +-pi/2 with inexact */
+            return x * PIO2_HI + 1.0 - 120f64;
+        } else {
+            return 0.0/(x-x);
+        }
+    }
+    /* |x| < 0.5 */
+    if ix < 0x3fe00000 {
+        /* if 0x1p-1022 <= |x| < 0x1p-26, avoid raising underflow */
+        if ix < 0x3e500000 && ix >= 0x00100000 {
+            return x;
+        } else {
+            return x + x*comp_r(x*x);
+        }
+    }
+    /* 1 > |x| >= 0.5 */
+    z = (1.0 - fabs(x))*0.5;
+    s = sqrt(z);
+    r = comp_r(z);
+    if ix >= 0x3fef3333 {  /* if |x| > 0.975 */
+        x = PIO2_HI-(2.*(s+s*r)-PIO2_LO);
+    } else {
+        let f : f64;
+        let c : f64;
+        /* f+c = sqrt(z) */
+        f = with_set_low_word(s,0);
+        c = (z-f*f)/(s+f);
+        x = 0.5*PIO2_HI - (2.0*s*r - (PIO2_LO-2.0*c) - (0.5*PIO2_HI-2.0*f));
+    }
+    if hx >> 31 != 0 {
+        return -x;
+    } else {
+        return x;
+    }
+}

--- a/src/math/asin.rs
+++ b/src/math/asin.rs
@@ -78,7 +78,7 @@ pub fn asin(mut x : f64) -> f64
         lx = get_low_word(x);
         if (ix-0x3ff00000 | lx) == 0 {
             /* asin(1) = +-pi/2 with inexact */
-            return x * PIO2_HI + 1.0 - 120f64;
+            return x * PIO2_HI + f64::from_bits(0x3870000000000000);
         } else {
             return 0.0/(x-x);
         }

--- a/src/math/asin.rs
+++ b/src/math/asin.rs
@@ -39,48 +39,46 @@
  *
  */
 
-use super::{get_high_word, get_low_word, with_set_low_word, fabs, sqrt};
+use super::{fabs, get_high_word, get_low_word, sqrt, with_set_low_word};
 
-const PIO2_HI : f64 = 1.57079632679489655800e+00; /* 0x3FF921FB, 0x54442D18 */
-const PIO2_LO : f64 = 6.12323399573676603587e-17; /* 0x3C91A626, 0x33145C07 */
+const PIO2_HI: f64 = 1.57079632679489655800e+00; /* 0x3FF921FB, 0x54442D18 */
+const PIO2_LO: f64 = 6.12323399573676603587e-17; /* 0x3C91A626, 0x33145C07 */
 /* coefficients for R(x^2) */
-const P_S0 : f64 =  1.66666666666666657415e-01; /* 0x3FC55555, 0x55555555 */
-const P_S1 : f64 = -3.25565818622400915405e-01; /* 0xBFD4D612, 0x03EB6F7D */
-const P_S2 : f64 =  2.01212532134862925881e-01; /* 0x3FC9C155, 0x0E884455 */
-const P_S3 : f64 = -4.00555345006794114027e-02; /* 0xBFA48228, 0xB5688F3B */
-const P_S4 : f64 =  7.91534994289814532176e-04; /* 0x3F49EFE0, 0x7501B288 */
-const P_S5 : f64 =  3.47933107596021167570e-05; /* 0x3F023DE1, 0x0DFDF709 */
-const Q_S1 : f64 = -2.40339491173441421878e+00; /* 0xC0033A27, 0x1C8A2D4B */
-const Q_S2 : f64 =  2.02094576023350569471e+00; /* 0x40002AE5, 0x9C598AC8 */
-const Q_S3 : f64 = -6.88283971605453293030e-01; /* 0xBFE6066C, 0x1B8D0159 */
-const Q_S4 : f64 =  7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
+const P_S0: f64 = 1.66666666666666657415e-01; /* 0x3FC55555, 0x55555555 */
+const P_S1: f64 = -3.25565818622400915405e-01; /* 0xBFD4D612, 0x03EB6F7D */
+const P_S2: f64 = 2.01212532134862925881e-01; /* 0x3FC9C155, 0x0E884455 */
+const P_S3: f64 = -4.00555345006794114027e-02; /* 0xBFA48228, 0xB5688F3B */
+const P_S4: f64 = 7.91534994289814532176e-04; /* 0x3F49EFE0, 0x7501B288 */
+const P_S5: f64 = 3.47933107596021167570e-05; /* 0x3F023DE1, 0x0DFDF709 */
+const Q_S1: f64 = -2.40339491173441421878e+00; /* 0xC0033A27, 0x1C8A2D4B */
+const Q_S2: f64 = 2.02094576023350569471e+00; /* 0x40002AE5, 0x9C598AC8 */
+const Q_S3: f64 = -6.88283971605453293030e-01; /* 0xBFE6066C, 0x1B8D0159 */
+const Q_S4: f64 = 7.70381505559019352791e-02; /* 0x3FB3B8C5, 0xB12E9282 */
 
-fn comp_r(z : f64) -> f64
-{
-    let p = z*(P_S0+z*(P_S1+z*(P_S2+z*(P_S3+z*(P_S4+z*P_S5)))));
-    let q = 1.0+z*(Q_S1+z*(Q_S2+z*(Q_S3+z*Q_S4)));
-    return p/q;
+fn comp_r(z: f64) -> f64 {
+    let p = z * (P_S0 + z * (P_S1 + z * (P_S2 + z * (P_S3 + z * (P_S4 + z * P_S5)))));
+    let q = 1.0 + z * (Q_S1 + z * (Q_S2 + z * (Q_S3 + z * Q_S4)));
+    return p / q;
 }
 
-pub fn asin(mut x : f64) -> f64
-{
-    let z : f64;
-    let r : f64;
-    let s : f64;
-    let hx : u32;
-    let ix : u32;
+pub fn asin(mut x: f64) -> f64 {
+    let z: f64;
+    let r: f64;
+    let s: f64;
+    let hx: u32;
+    let ix: u32;
 
     hx = get_high_word(x);
     ix = hx & 0x7fffffff;
     /* |x| >= 1 or nan */
     if ix >= 0x3ff00000 {
-        let lx : u32;
+        let lx: u32;
         lx = get_low_word(x);
-        if (ix-0x3ff00000 | lx) == 0 {
+        if (ix - 0x3ff00000 | lx) == 0 {
             /* asin(1) = +-pi/2 with inexact */
             return x * PIO2_HI + f64::from_bits(0x3870000000000000);
         } else {
-            return 0.0/(x-x);
+            return 0.0 / (x - x);
         }
     }
     /* |x| < 0.5 */
@@ -89,22 +87,23 @@ pub fn asin(mut x : f64) -> f64
         if ix < 0x3e500000 && ix >= 0x00100000 {
             return x;
         } else {
-            return x + x*comp_r(x*x);
+            return x + x * comp_r(x * x);
         }
     }
     /* 1 > |x| >= 0.5 */
-    z = (1.0 - fabs(x))*0.5;
+    z = (1.0 - fabs(x)) * 0.5;
     s = sqrt(z);
     r = comp_r(z);
-    if ix >= 0x3fef3333 {  /* if |x| > 0.975 */
-        x = PIO2_HI-(2.*(s+s*r)-PIO2_LO);
+    if ix >= 0x3fef3333 {
+        /* if |x| > 0.975 */
+        x = PIO2_HI - (2. * (s + s * r) - PIO2_LO);
     } else {
-        let f : f64;
-        let c : f64;
+        let f: f64;
+        let c: f64;
         /* f+c = sqrt(z) */
-        f = with_set_low_word(s,0);
-        c = (z-f*f)/(s+f);
-        x = 0.5*PIO2_HI - (2.0*s*r - (PIO2_LO-2.0*c) - (0.5*PIO2_HI-2.0*f));
+        f = with_set_low_word(s, 0);
+        c = (z - f * f) / (s + f);
+        x = 0.5 * PIO2_HI - (2.0 * s * r - (PIO2_LO - 2.0 * c) - (0.5 * PIO2_HI - 2.0 * f));
     }
     if hx >> 31 != 0 {
         return -x;

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -6,6 +6,7 @@ macro_rules! force_eval {
     };
 }
 
+mod asin;
 mod ceilf;
 mod expf;
 mod fabs;
@@ -36,11 +37,39 @@ mod truncf;
 //mod service;
 
 pub use self::{
-    ceilf::ceilf, expf::expf, fabs::fabs, fabsf::fabsf, floor::floor, floorf::floorf, fmodf::fmodf,
-    hypot::hypot, hypotf::hypotf, log::log, log10::log10, log10f::log10f, log1p::log1p,
-    log1pf::log1pf, log2::log2, log2f::log2f, logf::logf, powf::powf, round::round, roundf::roundf,
-    scalbn::scalbn, scalbnf::scalbnf, sqrt::sqrt, sqrtf::sqrtf, trunc::trunc, truncf::truncf,
+    asin::asin, ceilf::ceilf, expf::expf, fabs::fabs, fabsf::fabsf,
+    floor::floor, floorf::floorf, fmodf::fmodf, hypot::hypot, hypotf::hypotf,
+    log::log, log10::log10, log10f::log10f, log1p::log1p, log1pf::log1pf,
+    log2::log2, log2f::log2f, logf::logf, powf::powf, round::round,
+    roundf::roundf, scalbn::scalbn, scalbnf::scalbnf, sqrt::sqrt, sqrtf::sqrtf,
+    trunc::trunc, truncf::truncf,
 };
+
+#[inline]
+pub fn get_high_word(x : f64) -> u32 {
+    (x.to_bits() >> 32) as u32
+}
+
+#[inline]
+pub fn get_low_word(x : f64) -> u32 {
+    x.to_bits() as u32
+}
+
+#[inline]
+pub fn with_set_high_word(f : f64, hi : u32) -> f64 {
+    let mut tmp = f.to_bits();
+    tmp &= 0x00000000_ffffffff;
+    tmp |= (hi as u64) << 32;
+    f64::from_bits(tmp)
+}
+
+#[inline]
+pub fn with_set_low_word(f : f64, lo : u32) -> f64 {
+    let mut tmp = f.to_bits();
+    tmp &= 0xffffffff_00000000;
+    tmp |= lo as u64;
+    f64::from_bits(tmp)
+}
 
 fn isnanf(x: f32) -> bool {
     x.to_bits() & 0x7fffffff > 0x7f800000

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -37,26 +37,25 @@ mod truncf;
 //mod service;
 
 pub use self::{
-    asin::asin, ceilf::ceilf, expf::expf, fabs::fabs, fabsf::fabsf,
-    floor::floor, floorf::floorf, fmodf::fmodf, hypot::hypot, hypotf::hypotf,
-    log::log, log10::log10, log10f::log10f, log1p::log1p, log1pf::log1pf,
-    log2::log2, log2f::log2f, logf::logf, powf::powf, round::round,
-    roundf::roundf, scalbn::scalbn, scalbnf::scalbnf, sqrt::sqrt, sqrtf::sqrtf,
-    trunc::trunc, truncf::truncf,
+    asin::asin, ceilf::ceilf, expf::expf, fabs::fabs, fabsf::fabsf, floor::floor, floorf::floorf,
+    fmodf::fmodf, hypot::hypot, hypotf::hypotf, log::log, log10::log10, log10f::log10f,
+    log1p::log1p, log1pf::log1pf, log2::log2, log2f::log2f, logf::logf, powf::powf, round::round,
+    roundf::roundf, scalbn::scalbn, scalbnf::scalbnf, sqrt::sqrt, sqrtf::sqrtf, trunc::trunc,
+    truncf::truncf,
 };
 
 #[inline]
-pub fn get_high_word(x : f64) -> u32 {
+pub fn get_high_word(x: f64) -> u32 {
     (x.to_bits() >> 32) as u32
 }
 
 #[inline]
-pub fn get_low_word(x : f64) -> u32 {
+pub fn get_low_word(x: f64) -> u32 {
     x.to_bits() as u32
 }
 
 #[inline]
-pub fn with_set_high_word(f : f64, hi : u32) -> f64 {
+pub fn with_set_high_word(f: f64, hi: u32) -> f64 {
     let mut tmp = f.to_bits();
     tmp &= 0x00000000_ffffffff;
     tmp |= (hi as u64) << 32;
@@ -64,7 +63,7 @@ pub fn with_set_high_word(f : f64, hi : u32) -> f64 {
 }
 
 #[inline]
-pub fn with_set_low_word(f : f64, lo : u32) -> f64 {
+pub fn with_set_low_word(f: f64, lo: u32) -> f64 {
     let mut tmp = f.to_bits();
     tmp &= 0xffffffff_00000000;
     tmp |= lo as u64;

--- a/test-generator/src/main.rs
+++ b/test-generator/src/main.rs
@@ -697,7 +697,7 @@ f32i32_f32! {
 // With signature `fn(f64) -> f64`
 f64_f64! {
     // acos,
-    // asin,
+    asin,
     // atan,
     // cbrt,
     // ceil,


### PR DESCRIPTION
Fixes #7

Additionally adds inline functions for macros dealing with low and high words of f64s to the root module.
I'm not sure if you want these, but they seem sufficiently different to `get_bits` to merit a separate function.

Tell me if I need to change anything!