### PR TITLE
Replace isnanf with f32::is_nan

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ Check [PR #65] for an example.
   have any external dependencies (other than `core` itself).
 
 - Only use relative imports within the `math` directory / module, e.g. `use self::fabs::fabs` or
-`use super::isnanf`. Absolute imports from core are OK, e.g. `use core::u64`.
+`use super::fabsf`. Absolute imports from core are OK, e.g. `use core::u64`.
 
 - To reinterpret a float as an integer use the `to_bits` method. The MUSL code uses the
   `GET_FLOAT_WORD` macro, or a union, to do this operation.

--- a/src/math/fmodf.rs
+++ b/src/math/fmodf.rs
@@ -1,7 +1,5 @@
 use core::u32;
 
-use super::isnanf;
-
 #[inline]
 pub fn fmodf(x: f32, y: f32) -> f32 {
     let mut uxi = x.to_bits();
@@ -11,7 +9,7 @@ pub fn fmodf(x: f32, y: f32) -> f32 {
     let sx = uxi & 0x80000000;
     let mut i;
 
-    if uyi << 1 == 0 || isnanf(y) || ex == 0xff {
+    if uyi << 1 == 0 || y.is_nan() || ex == 0xff {
         return (x * y) / (x * y);
     }
 

--- a/src/math/mod.rs
+++ b/src/math/mod.rs
@@ -69,7 +69,3 @@ mod rem_pio2_large;
 mod rem_pio2f;
 
 use self::{k_cosf::k_cosf, k_sinf::k_sinf, rem_pio2_large::rem_pio2_large, rem_pio2f::rem_pio2f};
-
-fn isnanf(x: f32) -> bool {
-    x.to_bits() & 0x7fffffff > 0x7f800000
-}


### PR DESCRIPTION
As discussed in #94 this PR removes `isnanf` in favor of `f32::is_nan`.

Closes #94.